### PR TITLE
WireGuard Support

### DIFF
--- a/m2note.xml
+++ b/m2note.xml
@@ -14,4 +14,9 @@
         <project name="Moyster/android_kernel_m2note" path="kernel/meizu/m2note" remote="gh" revision="ng-7.1.2" />
         <project name="Moyster/android_vendor_meizu_m2note" path="vendor/meizu/m2note" remote="gh" revision="los-14.1" />
         <project name="Moyster/nougat_device_meizu_m2note" path="device/meizu/m2note" remote="gh" revision="los-14.1" />
+
+<!-- WireGuard -->
+        <remote name="zx2c4" fetch="https://git.zx2c4.com/" />
+        <project remote="zx2c4" name="android_kernel_wireguard" path="kernel/wireguard" revision="master" sync-s="true" />
+	
 </manifest>


### PR DESCRIPTION
I know you are a LineageOS purist and that you don't like to add features that aren't in LineageOS stock rom. But i was thinking that WireGuard would be a nice touch, it doesn't install any app, you just have to remove the whole ifdef around line 214 of kernel/meizu/m2note/net/wireguard/compat/compat.h. I already tested it and have a bootimage but i don't want to publish it on xda since i already messed up lot of times with credits and other stuff...